### PR TITLE
分割改为根据方向分配碰撞器

### DIFF
--- a/Assets/Quadtree Collider Detection/Example/Example Scene.unity
+++ b/Assets/Quadtree Collider Detection/Example/Example Scene.unity
@@ -234,6 +234,117 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 03b4fa466a219714481328d0cd98f12d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &343835778
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 343835782}
+  - component: {fileID: 343835781}
+  - component: {fileID: 343835780}
+  - component: {fileID: 343835779}
+  m_Layer: 0
+  m_Name: Collider (8)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &343835779
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 343835778}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 03b4fa466a219714481328d0cd98f12d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!212 &343835780
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 343835778}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.2, y: 0.2}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &343835781
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 343835778}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 941f899d293b0e44393c418cec6cc3fe, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  autoSubscribe: 1
+  isDetector: 1
+  _radius: 160
+--- !u!4 &343835782
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 343835778}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 85, y: 51, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 11
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &347891790
 GameObject:
   m_ObjectHideFlags: 0
@@ -316,6 +427,117 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &542776031
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 542776035}
+  - component: {fileID: 542776034}
+  - component: {fileID: 542776033}
+  - component: {fileID: 542776032}
+  m_Layer: 0
+  m_Name: Collider (6)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &542776032
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 542776031}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 03b4fa466a219714481328d0cd98f12d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!212 &542776033
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 542776031}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.2, y: 0.2}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &542776034
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 542776031}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 941f899d293b0e44393c418cec6cc3fe, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  autoSubscribe: 1
+  isDetector: 1
+  _radius: 100
+--- !u!4 &542776035
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 542776031}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1756, y: 272, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &838401674
 GameObject:
@@ -538,6 +760,117 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &980718766
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 980718770}
+  - component: {fileID: 980718769}
+  - component: {fileID: 980718768}
+  - component: {fileID: 980718767}
+  m_Layer: 0
+  m_Name: Collider (5)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &980718767
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 980718766}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 03b4fa466a219714481328d0cd98f12d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!212 &980718768
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 980718766}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.2, y: 0.2}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &980718769
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 980718766}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 941f899d293b0e44393c418cec6cc3fe, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  autoSubscribe: 1
+  isDetector: 1
+  _radius: 80
+--- !u!4 &980718770
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 980718766}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1239, y: 251, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1244684632
 GameObject:
@@ -864,6 +1197,228 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1893816044
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1893816048}
+  - component: {fileID: 1893816047}
+  - component: {fileID: 1893816046}
+  - component: {fileID: 1893816045}
+  m_Layer: 0
+  m_Name: Collider (9)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1893816045
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1893816044}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 03b4fa466a219714481328d0cd98f12d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!212 &1893816046
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1893816044}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.2, y: 0.2}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &1893816047
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1893816044}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 941f899d293b0e44393c418cec6cc3fe, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  autoSubscribe: 1
+  isDetector: 1
+  _radius: 140
+--- !u!4 &1893816048
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1893816044}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 889, y: 57, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 12
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2124692501
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2124692505}
+  - component: {fileID: 2124692504}
+  - component: {fileID: 2124692503}
+  - component: {fileID: 2124692502}
+  m_Layer: 0
+  m_Name: Collider (7)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2124692502
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2124692501}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 03b4fa466a219714481328d0cd98f12d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!212 &2124692503
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2124692501}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.2, y: 0.2}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &2124692504
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2124692501}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 941f899d293b0e44393c418cec6cc3fe, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  autoSubscribe: 1
+  isDetector: 1
+  _radius: 200
+--- !u!4 &2124692505
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2124692501}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 922, y: 696, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2128354228
 GameObject:

--- a/Assets/Quadtree Collider Detection/QuadtreeCollider/Quadtree/Quadtree/AddCollider.cs
+++ b/Assets/Quadtree Collider Detection/QuadtreeCollider/Quadtree/Quadtree/AddCollider.cs
@@ -30,7 +30,7 @@ namespace MtC.Tools.QuadtreeCollider
             // XXX：只假设了存入失败是因为碰撞器不在范围内，可能需要添加限制，或在每次循环时对四叉树总区域进行判断，如果节点就在总区域内部但还是存入失败则报错
 
             // 循环存入碰撞器，直到存入成功
-            while (!_root.AddCollider(collider))
+            while (!_root.AddColliderByArea(collider))
             {
                 // 如果存入失败则说明碰撞器在四叉树外，让四叉树向碰撞器方向生长
                 UpwordGroupToCollider(collider);

--- a/Assets/Quadtree Collider Detection/QuadtreeCollider/Quadtree/QuadtreeNode/AddCollider.cs
+++ b/Assets/Quadtree Collider Detection/QuadtreeCollider/Quadtree/QuadtreeNode/AddCollider.cs
@@ -83,7 +83,7 @@ namespace MtC.Tools.QuadtreeCollider
         }
 
         /// <summary>
-        /// 根据碰撞器相对于节点的位置向子节点存入碰撞器
+        /// 根据碰撞器相对于节点的方向向子节点存入碰撞器，只当碰撞器相对父节点的方向和节点相对父节点的方向相同时才存入
         /// </summary>
         /// <param name="collider"></param>
         /// <returns></returns>

--- a/Assets/Quadtree Collider Detection/QuadtreeCollider/Quadtree/QuadtreeNode/AddCollider.cs
+++ b/Assets/Quadtree Collider Detection/QuadtreeCollider/Quadtree/QuadtreeNode/AddCollider.cs
@@ -39,18 +39,7 @@ namespace MtC.Tools.QuadtreeCollider
         /// <returns></returns>
         private bool AddColliderIntoChildrenByArea(QuadtreeCollider collider)
         {
-            // 遍历子节点存入碰撞器
-            foreach (QuadtreeNode child in _children)
-            {
-                // 如果有一个子节点存入成功则返回存入成功
-                if (child.AddColliderByArea(collider))
-                {
-                    return true;
-                }
-            }
-
-            // 正常流程中不会运行到的所有子节点都保存失败的情况
-            throw new ArgumentOutOfRangeException("向范围是 " + _area + " 的节点的子节点存入碰撞器 " + collider + " 时发生错误：碰撞器没有存入任何子节点");
+            return AddColliderIntoChildren(collider, (node, colliderTemp) => node.AddColliderByArea(colliderTemp));
         }
 
         /// <summary>
@@ -89,11 +78,22 @@ namespace MtC.Tools.QuadtreeCollider
         /// <returns></returns>
         private bool AddColliderIntoChildrenByDirection(QuadtreeCollider collider)
         {
+            return AddColliderIntoChildren(collider, (node, colliderTemp) => node.AddColliderByDirection(colliderTemp));
+        }
+
+        /// <summary>
+        /// 将碰撞器按照指定标准存入到子节点
+        /// </summary>
+        /// <param name="collider">要存入的碰撞器</param>
+        /// <param name="addCollider">存入标准，返回 true 表示碰撞器可以存入到这个子节点中</param>
+        /// <returns></returns>
+        private bool AddColliderIntoChildren(QuadtreeCollider collider, Func<QuadtreeNode, QuadtreeCollider,bool> addCollider)
+        {
             // 遍历子节点存入碰撞器
             foreach (QuadtreeNode child in _children)
             {
                 // 如果有一个子节点存入成功则返回存入成功
-                if (child.AddColliderByDirection(collider))
+                if (addCollider(child, collider))
                 {
                     return true;
                 }

--- a/Assets/Quadtree Collider Detection/QuadtreeCollider/Quadtree/QuadtreeNode/AddCollider.cs
+++ b/Assets/Quadtree Collider Detection/QuadtreeCollider/Quadtree/QuadtreeNode/AddCollider.cs
@@ -24,22 +24,12 @@ namespace MtC.Tools.QuadtreeCollider
             // 有子节点，发给子节点保存
             if (HaveChildren())
             {
-                return AddColliderIntoChildrenByArea(collider);
+                return AddColliderIntoChildren(collider, (node, colliderTemp) => node.AddColliderByArea(colliderTemp));
             }
 
             // 在范围内，而且没有子节点，保存节点并返回保存成功
             AddColliderIntoSelf(collider);
             return true;
-        }
-
-        /// <summary>
-        /// 通过节点范围向子节点存入碰撞器，只当碰撞器在节点范围内时才存入
-        /// </summary>
-        /// <param name="collider"></param>
-        /// <returns></returns>
-        private bool AddColliderIntoChildrenByArea(QuadtreeCollider collider)
-        {
-            return AddColliderIntoChildren(collider, (node, colliderTemp) => node.AddColliderByArea(colliderTemp));
         }
 
         /// <summary>
@@ -63,22 +53,12 @@ namespace MtC.Tools.QuadtreeCollider
             // 有子节点，发给子节点保存
             if (HaveChildren())
             {
-                return AddColliderIntoChildrenByDirection(collider);
+                return AddColliderIntoChildren(collider, (node, colliderTemp) => node.AddColliderByDirection(colliderTemp));
             }
 
             // 没有子节点，保存节点并返回保存成功
             AddColliderIntoSelf(collider);
             return true;
-        }
-
-        /// <summary>
-        /// 根据碰撞器相对于节点的方向向子节点存入碰撞器，只当碰撞器相对父节点的方向和节点相对父节点的方向相同时才存入
-        /// </summary>
-        /// <param name="collider"></param>
-        /// <returns></returns>
-        private bool AddColliderIntoChildrenByDirection(QuadtreeCollider collider)
-        {
-            return AddColliderIntoChildren(collider, (node, colliderTemp) => node.AddColliderByDirection(colliderTemp));
         }
 
         /// <summary>
@@ -173,7 +153,7 @@ namespace MtC.Tools.QuadtreeCollider
             // 把当前节点的碰撞器全部存入到子节点，这里为了防止可能有碰撞器已经离开了节点范围，需要根据方向而不是范围存入
             foreach (QuadtreeCollider collider in _colliders)
             {
-                AddColliderIntoChildrenByDirection(collider);
+                AddColliderIntoChildren(collider, (node, colliderTemp) => node.AddColliderByDirection(colliderTemp));
             }
 
             // 清空当前节点存储的碰撞器

--- a/Assets/Quadtree Collider Detection/QuadtreeCollider/Quadtree/QuadtreeNode/AddCollider.cs
+++ b/Assets/Quadtree Collider Detection/QuadtreeCollider/Quadtree/QuadtreeNode/AddCollider.cs
@@ -9,11 +9,11 @@ namespace MtC.Tools.QuadtreeCollider
     internal partial class QuadtreeNode
     {
         /// <summary>
-        /// 向四叉树中存入碰撞器
+        /// 根据节点范围向四叉树中存入碰撞器，只当碰撞器在节点范围内时才存入
         /// </summary>
         /// <param name="collider">存入的碰撞器</param>
         /// <returns> 如果成功存入，返回 true </returns>
-        internal bool AddCollider(QuadtreeCollider collider)
+        internal bool AddColliderByArea(QuadtreeCollider collider)
         {
             // 碰撞器不在节点范围内，返回存入失败
             if (!_area.Contains(collider.Position))
@@ -24,26 +24,76 @@ namespace MtC.Tools.QuadtreeCollider
             // 有子节点，发给子节点保存
             if (HaveChildren())
             {
-                return AddColliderIntoChildren(collider);
+                return AddColliderIntoChildrenByArea(collider);
             }
 
-            // 保存节点并返回保存成功
+            // 在范围内，而且没有子节点，保存节点并返回保存成功
             AddColliderIntoSelf(collider);
             return true;
         }
 
         /// <summary>
-        /// 向子节点存入碰撞器
+        /// 通过节点范围向子节点存入碰撞器，只当碰撞器在节点范围内时才存入
         /// </summary>
         /// <param name="collider"></param>
         /// <returns></returns>
-        private bool AddColliderIntoChildren(QuadtreeCollider collider)
+        private bool AddColliderIntoChildrenByArea(QuadtreeCollider collider)
         {
             // 遍历子节点存入碰撞器
             foreach (QuadtreeNode child in _children)
             {
                 // 如果有一个子节点存入成功则返回存入成功
-                if (child.AddCollider(collider))
+                if (child.AddColliderByArea(collider))
+                {
+                    return true;
+                }
+            }
+
+            // 正常流程中不会运行到的所有子节点都保存失败的情况
+            throw new ArgumentOutOfRangeException("向范围是 " + _area + " 的节点的子节点存入碰撞器 " + collider + " 时发生错误：碰撞器没有存入任何子节点");
+        }
+
+        /// <summary>
+        /// 根据碰撞器相对于节点的位置向四叉树中存入碰撞器
+        /// </summary>
+        /// <param name="collider"></param>
+        /// <returns></returns>
+        private bool AddColliderByDirection(QuadtreeCollider collider)
+        {
+            // 当前节点相对于父节点的方向与碰撞器相对于父节点的方向，在 X 轴上是否一致
+            bool colliderAndNodeOnSameXSide = !((area.center.x > _parent.area.center.x) ^ (collider.Position.x > _parent.area.center.x));
+            // 当前节点相对于父节点的方向与碰撞器相对于父节点的方向，在 Y 轴上是否一致
+            bool colliderAndNodeOnSameYSide = !((area.center.y > _parent.area.center.y) ^ (collider.Position.y > _parent.area.center.y));
+
+            // 只要有一个不一致的，就说明碰撞器不应该被存入到这个节点里，直接返回
+            if (!colliderAndNodeOnSameXSide || !colliderAndNodeOnSameYSide)
+            {
+                return false;
+            }
+
+            // 有子节点，发给子节点保存
+            if (HaveChildren())
+            {
+                return AddColliderIntoChildrenByDirection(collider);
+            }
+
+            // 没有子节点，保存节点并返回保存成功
+            AddColliderIntoSelf(collider);
+            return true;
+        }
+
+        /// <summary>
+        /// 根据碰撞器相对于节点的位置向子节点存入碰撞器
+        /// </summary>
+        /// <param name="collider"></param>
+        /// <returns></returns>
+        private bool AddColliderIntoChildrenByDirection(QuadtreeCollider collider)
+        {
+            // 遍历子节点存入碰撞器
+            foreach (QuadtreeNode child in _children)
+            {
+                // 如果有一个子节点存入成功则返回存入成功
+                if (child.AddColliderByDirection(collider))
                 {
                     return true;
                 }
@@ -89,28 +139,6 @@ namespace MtC.Tools.QuadtreeCollider
         /// </summary>
         private void Split()
         {
-            /*
-             *  清除掉不在自己区域内的碰撞器，防止下发碰撞器失败
-             *  分割处子节点并下发碰撞器
-             *  把清除掉的那些碰撞器重新存入四叉树
-             *  
-             *  实际是进行了一次位置更新，但为了防止节点碰撞器互相越界导致的多重更新将分割写在存入和取出中间
-             */
-            // 将节点保存的但是已经离开了节点范围的碰撞器从四叉树中移除并保存
-            List<QuadtreeCollider> outOfAreaColliders = GetAndRemoveCollidersOutOfField();
-
-            // 进行分割
-            DoSplite();
-
-            // 将之前移除的节点重新存入四叉树
-            ResetCollidersIntoQuadtree(outOfAreaColliders);
-        }
-
-        /// <summary>
-        /// 进行分割节点
-        /// </summary>
-        private void DoSplite()
-        {
             // 创建子节点
             CreateChildren();
 
@@ -142,14 +170,16 @@ namespace MtC.Tools.QuadtreeCollider
         /// </summary>
         private void SetAllColliderIntoChindren()
         {
-            // 把当前节点的碰撞器全部存入到子节点
+            // 把当前节点的碰撞器全部存入到子节点，这里为了防止可能有碰撞器已经离开了节点范围，需要根据方向而不是范围存入
             foreach (QuadtreeCollider collider in _colliders)
             {
-                AddColliderIntoChildren(collider);
+                AddColliderIntoChildrenByDirection(collider);
             }
 
             // 清空当前节点存储的碰撞器
             _colliders.Clear();
+
+            // 此处如果使用先移除越界的碰撞器分割后重新存入树，则有可能因为移除节点导致需要合并，形成 分割反而导致了合并 的逻辑套娃
         }
     }
 }


### PR DESCRIPTION
原本的分割逻辑是先将越界的碰撞器移除，之后分割，之后把移除的碰撞器重新存入。

这会导致合并逻辑发生问题：假设分割时移除的节点过多，导致了这个节点甚至这个节点的父节点达到了合并条件，这就会导致“分割导致了合并”的逻辑套娃。

现在改为根据方向进行存入，没有了移除操作，就不会导致合并。